### PR TITLE
A minor change to conform with -Werror

### DIFF
--- a/libcsv.c
+++ b/libcsv.c
@@ -172,7 +172,7 @@ csv_fini(struct csv_parser *p, void (*cb1)(void *, size_t, void *), void (*cb2)(
     return -1;
   }
 
-  switch (p->pstate) {
+  switch (pstate) {
     case FIELD_MIGHT_HAVE_ENDED:
       p->entry_pos -= p->spaces + 1;  /* get rid of spaces and original quote */
       /* Fall-through */


### PR DESCRIPTION
The compilation of a program which uses libcsv will halt if -Werror is specified due to the variable 'pstate', which is being set but not used. 
$ warning: variable 'pstate' set but not used [-Wunused-but-set-variable]

I can see that 'pstate' is being declared for consistency with the shared macros, but that it doesn't otherwise deviate from the value of 'p->pstate' before the switch (they were equal throughout the tests). So I'm proposing a simple change to give 'pstate' a job.

I might be totally wrong about this, so don't hurt me. I left a note in my pocket naming you as my killer.